### PR TITLE
fix 华为P系列手机上 删除富文本的bug，demo可复现

### DIFF
--- a/lib/src/extended_editable_text.dart
+++ b/lib/src/extended_editable_text.dart
@@ -889,6 +889,10 @@ class ExtendedEditableTextState extends State<ExtendedEditableText>
       return;
     }
 
+    // 如果上一个系统更新的值和这次的值相等，不做更新处理，华为p系列手机会连续调2次updateEditingValue
+    if (value.text == (_lastKnownRemoteTextEditingValue?.text ?? "") )
+      return;
+
     value = _handleSpecialTextSpan(value);
     if (value.text != _value.text) {
       _hideSelectionOverlayIfNeeded();


### PR DESCRIPTION
已复现机型P30pro p20
原因是华为p系列手机调用updateEditingValue2次，2次是一样的值，在删除富文本时
复现步骤，输入多个表情符，然后调用系统键盘的删除
1. 第一次删除成功，且富文本匹配成功
2. 第二次还是一样的值，这时会认为这是新的值，把第一次的值覆盖了