### PR TITLE
Fix removal of nullOk from MediaQuery

### DIFF
--- a/lib/src/extended_editable_text.dart
+++ b/lib/src/extended_editable_text.dart
@@ -2398,9 +2398,9 @@ class ExtendedEditableTextState extends State<ExtendedEditableText>
         dragStartBehavior: widget.dragStartBehavior,
         restorationId: widget.restorationId,
         viewportBuilder: (BuildContext context, ViewportOffset offset) {
-          if (offset != null && offset is ScrollPosition) {
-            if (offset.minScrollExtent != null &&
-                offset.maxScrollExtent != null) {
+            // https://github.com/flutter/flutter/issues/66250
+          if (offset is ScrollPosition) {
+            if (offset.hasContentDimensions) {
               // pixels should >= minScrollExtent
               // pixels should <= maxScrollExtent
               offset.correctPixels(offset.pixels.clamp(

--- a/lib/src/extended_text_field.dart
+++ b/lib/src/extended_text_field.dart
@@ -869,7 +869,7 @@ class _ExtendedTextFieldState extends State<ExtendedTextField>
 
   bool get _canRequestFocus {
     final NavigationMode mode =
-        MediaQuery.of(context, nullOk: true)?.navigationMode ??
+        MediaQuery.maybeOf(context)?.navigationMode ??
             NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:


### PR DESCRIPTION
- Fix #109 removal of `nullOk` with `MediaQuery.maybeOf(context)` 
- Fix https://github.com/flutter/flutter/issues/66250 null check error with minScrollExtent