### PR TITLE
## 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 7.0.0
+
+* Breaking change: [SpecialText.getContent] is not include endflag now.(please check if you call getContent and your endflag length is more than 1)
+* Fix demo manualDelete error #120
+
 ## 6.0.1
 
-* Fix issue that toolbar is not shown when double tap 
+* Fix issue that toolbar is not shown when double tap
 * Fix throw exception when selectWordAtOffset
 
 ## 6.0.0
@@ -10,20 +15,20 @@
 ## 5.0.4
 
 * Fix toolbar is not show after some behaviour #107
-  
+
 ## 5.0.3
 
 * Fix miss TextStyle for specialTextSpanBuilder #89
-  
+
 ## 5.0.2
 
 * Fix wrong position of caret
-  
+
 ## 5.0.1
 
 * change handleSpecialText to hasSpecialInlineSpanBase(extended_text_library)
 * add hasPlaceholderSpan(extended_text_library)
-  
+
 ## 5.0.0
 
 * Merge from Flutter v1.22

--- a/example/lib/pages/complex/text_demo.dart
+++ b/example/lib/pages/complex/text_demo.dart
@@ -67,7 +67,10 @@ class _TextDemoState extends State<TextDemo> {
         title: const Text('special text'),
         actions: <Widget>[
           TextButton(
-            child: const Icon(Icons.backspace),
+            child: const Icon(
+              Icons.backspace,
+              color: Colors.white,
+            ),
             onPressed: manualDelete,
           )
         ],

--- a/example/lib/special_text/image_text.dart
+++ b/example/lib/special_text/image_text.dart
@@ -22,7 +22,7 @@ class ImageText extends SpecialText {
   @override
   InlineSpan finishText() {
     ///content already has endflag '/'
-    final String text = flag + getContent() + '>';
+    final String text = toString();
 
     ///'<img src='$url'/>'
 //    var index1 = text.indexOf(''') + 1;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,12 +23,12 @@ dependencies:
 
 
   cupertino_icons: ^0.1.2
-  extended_text: ^5.0.0  
+  extended_text: ^6.0.0
   extended_text_field:
-    path: ../  
+    path: ../
   ff_annotation_route_library: ^2.0.1-non-null-safety
   flutter:
-    sdk: flutter  
+    sdk: flutter
   html: any
   loading_more_list: ^3.1.1
   oktoast: ^2.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extended_text_field
 description: Extended official text field to build special text like inline image, @somebody, custom background etc quickly.It also support to build custom seleciton toolbar and handles.
-version: 6.0.1
+version: 7.0.0
 homepage: https://github.com/fluttercandies/extended_text_field
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=2.0.0"
 dependencies:
 
-  extended_text_library: ^5.0.2
+  extended_text_library: ^6.0.0
   flutter:
     sdk: flutter
 dev_dependencies:


### PR DESCRIPTION
* Breaking change: [SpecialText.getContent] is not include endflag now.(please check if you call getContent and your endflag length is more than 1)
* Fix demo manualDelete error #120