### PR TITLE
Expose the Focus.onKeyEvent to SpecialTextSpanBuilder.handleKeyEventCallback to give it a chance to handle keyboard events

### DIFF
--- a/lib/src/extended/widgets/editable_text.dart
+++ b/lib/src/extended/widgets/editable_text.dart
@@ -300,6 +300,10 @@ class ExtendedEditableTextState extends _EditableTextState {
                 focusNode: widget.focusNode,
                 includeSemantics: false,
                 debugLabel: kReleaseMode ? null : 'EditableText',
+                onKeyEvent: extendedEditableText.specialTextSpanBuilder != null
+                    ? extendedEditableText
+                        .specialTextSpanBuilder!.handleKeyEventCallback
+                    : null,
                 child: NotificationListener<ScrollNotification>(
                   onNotification: (ScrollNotification notification) {
                     _handleContextMenuOnScroll(notification);


### PR DESCRIPTION
Expose the Focus.onKeyEvent to SpecialTextSpanBuilder.handleKeyEventCallback to give it a chance to handle keyboard events.
This PR needs to be synchronized with the https://github.com/fluttercandies/extended_text_library/pull/44
