### PR TITLE
 Change spellCheckSuggestionsToolbarBuilder to extendedSpellCheckSussgionToolbarBuilder

### DIFF
--- a/lib/src/extended/widgets/editable_text.dart
+++ b/lib/src/extended/widgets/editable_text.dart
@@ -434,9 +434,9 @@ class ExtendedEditableTextState extends _EditableTextState {
     }
 
     assert(
-      _spellCheckConfiguration.spellCheckSuggestionsToolbarBuilder != null,
-      'spellCheckSuggestionsToolbarBuilder must be defined in '
-      'SpellCheckConfiguration to show a toolbar with spell check '
+    extendedSpellCheckConfiguration.extendedSpellCheckSuggestionsToolbarBuilder != null,
+      'extendedSpellCheckSuggestionsToolbarBuilder must be defined in '
+      'ExtendedSpellCheckConfiguration to show a toolbar with spell check '
       'suggestions',
     );
 


### PR DESCRIPTION
 The value of spellCheckSuggestionsToolbarBuilder somehow was abandoned
![image](https://github.com/user-attachments/assets/9f49bb4b-67a0-4c55-8284-040359d051e7)

It accidentally causes the assert error here
![image](https://github.com/user-attachments/assets/a1c5a90b-ddf6-400c-bf66-abf4b0aeec3f)
 
